### PR TITLE
Remove mac and windows from CI

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -14,8 +14,6 @@ jobs:
           - "nightly"
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:


### PR DESCRIPTION
I don't think they are needed and are only slowing the CI