### PR TITLE
Better support for tables, including named tuples of vectors

### DIFF
--- a/src/DataSkimmer.jl
+++ b/src/DataSkimmer.jl
@@ -104,10 +104,12 @@ end
 
 Skim any Tables.jl compatible table.
 """
-function skim(data)::Skimmed
-    if !Tables.istable(data)
+function skim(input_data)::Skimmed
+    if !Tables.istable(input_data)
         throw(ArgumentError("Input to skim() must be a valid Tables.jl table."))
     end
+
+    data = Tables.columns(input_data)
 
     data_schema = Tables.schema(data)
     if isnothing(data_schema)

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -5,7 +5,11 @@ function count_rows(data)::Integer
     if Tables.rowaccess(data)
         return length(Tables.rows(data))
     else
-        # data already Tables.columns
+        # Because we wrapped in
+        # Tables.columns earlier, the
+        # output of `getcolumn(data, 1)`
+        # is guaranteed to have `length`
+        # defined.
         return nrows = length(Tables.getcolumn(data, 1))
     end
 end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -5,7 +5,8 @@ function count_rows(data)::Integer
     if Tables.rowaccess(data)
         return length(Tables.rows(data))
     else
-        @error "Can't count the number of rows"
+        # data already Tables.columns
+        return nrows = length(Tables.getcolumn(data, 1))
     end
 end
 
@@ -15,11 +16,7 @@ Count the number of columns of a table.
 function count_columns(data)::Integer
     data_schema = Tables.schema(data)
     if isnothing(data_schema)
-        if Tables.columnaccess(data)
-            return length(Tables.columns(data))
-        else
-            @error "Can't count the number of columns"
-        end
+        return length(Tables.columnnames(data))
     else
         return length(data_schema.names)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,8 @@ iris_dataframe = RDatasets.dataset("datasets", "iris")
 base_table = [
     (A = 1, B = "one", C = Date(2021, 1, 1)),
     (A = 2, B = "two", C = Date(2021, 1, 2)),
-    (A = 3, B = "three", C = Date(2021, 1, 3))]
+    (A = 3, B = "three", C = Date(2021, 1, 3)),
+]
 
 datasets = Dict(
     "iris_dataframe" => iris_dataframe,
@@ -24,7 +25,7 @@ datasets = Dict(
     "loomis_dataframe" => RDatasets.dataset("COUNT", "loomis"),
     "empty_dataframe" => DataFrame(x = [], y = Int64[], z = String[]),
     "vector_of_nt" => base_table,
-    "nt_of_vectors" => Tables.columntable(base_table)
+    "nt_of_vectors" => Tables.columntable(base_table),
 )
 
 @testset "Test DataSkimmer.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,18 +10,21 @@ using TimeSeries: TimeArray
 
 iris_dataframe = RDatasets.dataset("datasets", "iris")
 
+base_table = [
+    (A = 1, B = "one", C = Date(2021, 1, 1)),
+    (A = 2, B = "two", C = Date(2021, 1, 2)),
+    (A = 3, B = "three", C = Date(2021, 1, 3))]
+
 datasets = Dict(
     "iris_dataframe" => iris_dataframe,
     "iris_csv" => CSV.File(seekstart(CSV.write(IOBuffer(), iris_dataframe))),
-    "struct_array" => StructArray([
-        (A = 1, B = "one", C = Date(2021, 1, 1)),
-        (A = 2, B = "two", C = Date(2021, 1, 2)),
-        (A = 3, B = "three", C = Date(2021, 1, 3)),
-    ]),
+    "struct_array" => StructArray(base_table),
     "timearray" =>
         TimeArray(RDatasets.dataset("ggplot2", "economics"), timestamp = :Date),
     "loomis_dataframe" => RDatasets.dataset("COUNT", "loomis"),
     "empty_dataframe" => DataFrame(x = [], y = Int64[], z = String[]),
+    "vector_of_nt" => base_table,
+    "nt_of_vectors" => Tables.columntable(base_table)
 )
 
 @testset "Test DataSkimmer.jl" begin


### PR DESCRIPTION
As discussed on Discourse, here I add better support for `NamedTuples` of `Vectors` and `Vector`s of `NamedTuple`s. 

I do this by calling `Tables.columns` on the input data so that we have a few more guarantees about how it works. 

This diff is deliberately small. I think I am probably under-counting the number of guarantees `Tables.columns` gives us and we could simplify the code more. But tests pass. 

In the process of working on this, I noticed the possibility of lots of performance improvements and some more "Julian" refactoring of the code. I hope to be able to work on these issues in a later PR.