### PR TITLE
Add to DateTimeColumn struct a Union with Missing (fix). Add an AllMissingColumn struct to hold columns with all values missing.

### DIFF
--- a/src/DataSkimmer.jl
+++ b/src/DataSkimmer.jl
@@ -73,8 +73,8 @@ struct DateTimeColumn
     type::Type
     n_missing::Int64
     completion_rate::Float64
-    minimum::Union{Dates.Date, Dates.DateTime}
-    maximum::Union{Dates.Date, Dates.DateTime}
+    minimum::Union{Dates.Date, Dates.DateTime, Missing}
+    maximum::Union{Dates.Date, Dates.DateTime, Missing}
     histogram::String
 
     function DateTimeColumn(data, column_name)

--- a/src/DataSkimmer.jl
+++ b/src/DataSkimmer.jl
@@ -96,16 +96,11 @@ end
 struct AllMissingColumn
     name::Symbol
     type::Type
-    n_missing::Int64
-    completion_rate::Float64
 
     function AllMissingColumn(data, column_name)
-        n_missing = count(ismissing, Tables.getcolumn(data, column_name))
         return new(
             column_name,
             Tables.columntype(data, column_name),
-            n_missing,
-            1 - (n_missing / count_rows(data)),
         )
     end
 end
@@ -290,9 +285,7 @@ function Base.show(io::IO, allmissing_columns::Vector{AllMissingColumn})
     n_allmissing_columns = length(allmissing_columns)
     if n_allmissing_columns > 0
         allmissing_table = StructArray(allmissing_columns)
-        allmissing_header = ["Name", "Type", "Missings", "Complete"]
-        allmissing_formatters =
-            formatter_percent(allmissing_table, [:completion_rate]; n_decimal_places = 1)
+        allmissing_header = ["Name", "Type"]
         println(
             io,
             "$(n_allmissing_columns) allmissing column$(plural(n_allmissing_columns))",
@@ -302,7 +295,6 @@ function Base.show(io::IO, allmissing_columns::Vector{AllMissingColumn})
             allmissing_table;
             header = allmissing_header,
             backend = Val(:text),
-            formatters = allmissing_formatters,
         )
     end
     return

--- a/src/DataSkimmer.jl
+++ b/src/DataSkimmer.jl
@@ -98,10 +98,7 @@ struct AllMissingColumn
     type::Type
 
     function AllMissingColumn(data, column_name)
-        return new(
-            column_name,
-            Tables.columntype(data, column_name),
-        )
+        return new(column_name, Tables.columntype(data, column_name))
     end
 end
 
@@ -177,10 +174,16 @@ function skim(input_data)::Skimmed
         length(numeric_columns),
         length(categorical_columns),
         length(datetime_columns),
-        length(allmissing_columns)
+        length(allmissing_columns),
     )
 
-    return Skimmed(summary, numeric_columns, categorical_columns, datetime_columns, allmissing_columns)
+    return Skimmed(
+        summary,
+        numeric_columns,
+        categorical_columns,
+        datetime_columns,
+        allmissing_columns,
+    )
 end
 
 function Base.show(io::IO, summary::Summary)
@@ -290,12 +293,7 @@ function Base.show(io::IO, allmissing_columns::Vector{AllMissingColumn})
             io,
             "$(n_allmissing_columns) allmissing column$(plural(n_allmissing_columns))",
         )
-        pretty_table(
-            io,
-            allmissing_table;
-            header = allmissing_header,
-            backend = Val(:text),
-        )
+        pretty_table(io, allmissing_table; header = allmissing_header, backend = Val(:text))
     end
     return
 end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -26,9 +26,10 @@ function count_columns(data)::Integer
     end
 end
 
-is_datetime(x)::Bool = x <: Union{Dates.Date, Dates.DateTime, Missing}
-is_numeric(x)::Bool = x <: Union{Real, Missing}
-is_categorical(x)::Bool = !is_numeric(x) && !is_datetime(x)
+is_allmissing(x)::Bool = x <: Missing 
+is_datetime(x)::Bool = !is_allmissing(x) && x <: Union{Dates.Date, Dates.DateTime, Missing}
+is_numeric(x)::Bool = !is_allmissing(x) &&  x <: Union{Real, Missing}
+is_categorical(x)::Bool = !is_allmissing(x) && !is_numeric(x) && !is_datetime(x)
 
 function formatter_numeric(data, columns_to_format; n_decimal_places::Integer)
     format_string = "%.$(n_decimal_places)f"

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -26,9 +26,9 @@ function count_columns(data)::Integer
     end
 end
 
-is_allmissing(x)::Bool = x <: Missing 
+is_allmissing(x)::Bool = x <: Missing
 is_datetime(x)::Bool = !is_allmissing(x) && x <: Union{Dates.Date, Dates.DateTime, Missing}
-is_numeric(x)::Bool = !is_allmissing(x) &&  x <: Union{Real, Missing}
+is_numeric(x)::Bool = !is_allmissing(x) && x <: Union{Real, Missing}
 is_categorical(x)::Bool = !is_allmissing(x) && !is_numeric(x) && !is_datetime(x)
 
 function formatter_numeric(data, columns_to_format; n_decimal_places::Integer)


### PR DESCRIPTION
Continued fix to the problem of Date or DateTime columns with missing rows filing incorrectly.

**_Without_** this change, skim still throws an error:
```
ERROR: MethodError: Cannot `convert` an object of type 
  Missing to an object of type 
  Union{Date, DateTime}
Closest candidates are:
  convert(::Type{T}, ::T) where T at essentials.jl:205
Stacktrace:
 [1] DataSkimmer.DateTimeColumn(data::DataFrames.DataFrameColumns{DataFrame}, column_name::Symbol)
   @ DataSkimmer ~/.julia/packages/DataSkimmer/83AtG/src/DataSkimmer.jl:83
```