### PR TITLE
Skip missings in datetime columns

### DIFF
--- a/src/DataSkimmer.jl
+++ b/src/DataSkimmer.jl
@@ -83,6 +83,7 @@ struct DateTimeColumn
 
     function DateTimeColumn(data, column_name)
         column = Tables.getcolumn(data, column_name)
+        column = skipmissing(column)
         n_missing = count(ismissing, column)
         return new(
             column_name,


### PR DESCRIPTION
Aggregations of datetime columns (i.e. min and max) will now ignore missing values. 

Fixes #65.

