### PR TITLE
Add support for time columns

### DIFF
--- a/src/DataSkimmer.jl
+++ b/src/DataSkimmer.jl
@@ -77,8 +77,8 @@ struct DateTimeColumn
     type::Type
     n_missing::Int64
     completion_rate::Float64
-    minimum::Union{Dates.Date, Dates.DateTime, Missing}
-    maximum::Union{Dates.Date, Dates.DateTime, Missing}
+    minimum::Union{Dates.Date, Dates.DateTime, Dates.Time, Missing}
+    maximum::Union{Dates.Date, Dates.DateTime, Dates.Time, Missing}
     histogram::String
 
     function DateTimeColumn(data, column_name)

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -27,7 +27,8 @@ function count_columns(data)::Integer
 end
 
 is_allmissing(x)::Bool = x <: Missing
-is_datetime(x)::Bool = !is_allmissing(x) && x <: Union{Dates.Date, Dates.DateTime, Missing}
+is_datetime(x)::Bool =
+    !is_allmissing(x) && x <: Union{Dates.Date, Dates.DateTime, Dates.Time, Missing}
 is_numeric(x)::Bool = !is_allmissing(x) && x <: Union{Real, Missing}
 is_categorical(x)::Bool = !is_allmissing(x) && !is_numeric(x) && !is_datetime(x)
 

--- a/src/histogram.jl
+++ b/src/histogram.jl
@@ -17,15 +17,25 @@ end
 Construct a histogram made of a sequence of unicode bar characters.
 """
 function unicode_histogram(x, n_bins::Integer)::String
+    # Special case for time data
+    if eltype(x) == Dates.Time
+        return unicode_histogram(getfield.(x .- Dates.Time(0), :value), n_bins)
+    end
+
+    # Special case for when all the datapoints are missing
     n_nonmissing_datapoints = count(!ismissing, x)
     if n_nonmissing_datapoints == 0
         return repeat(" ", n_bins)
     end
+
     x = skipmissing(x)
     min_value, max_value = extrema(x)
+
+    # Special case for when all of the non-missing values are the same
     if max_value == min_value
         return repeat(" ", n_bins)
     end
+
     bin_edges = range(min_value, max_value; length = n_bins + 1)
     weights = [
         if index == 1

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -1,8 +1,8 @@
 # The most basic Tables.jl table is a vector of named tuples
 vector_of_named_tuples = [
-    (a = 1, b = "one", c = Dates.Date(2021, 1, 1)),
-    (a = 2, b = "two", c = Dates.Date(2021, 1, 2)),
-    (a = 3, b = "three", c = Dates.Date(2021, 1, 3)),
+    (a = 1, b = "one", c = Date(2021, 1, 1), d = Time(1, 2, 3)),
+    (a = 2, b = "two", c = Date(2021, 1, 2), d = Time(2, 3, 4)),
+    (a = 3, b = "three", c = Date(2021, 1, 3), d = Time(3, 4, 5)),
 ]
 
 # The famous iris dataset to test DataFrames.jl dataframes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,24 @@ include("datasets.jl")
             @test output isa String
             @test length(output) == n_bars
         end
+        @testset "Test unicode_histogram works with dates" begin
+            n_bars = 5
+            output = DataSkimmer.unicode_histogram(
+                range(Date(2000, 1, 1), Date(2048, 1, 1); length = 10),
+                n_bars,
+            )
+            @test output isa String
+            @test length(output) == n_bars
+        end
+        @testset "Test unicode_histogram works with times" begin
+            n_bars = 5
+            output = DataSkimmer.unicode_histogram(
+                range(Time(0, 0, 0), Time(23, 59, 59); step = Minute(7)),
+                n_bars,
+            )
+            @test output isa String
+            @test length(output) == n_bars
+        end
     end
 
     @testset "Test column type helper functions" begin


### PR DESCRIPTION
This should fix #70 by adding the `Dates.Time` type to typehints and adding a special case to the unicode histogram function. Also adds some unit tests for date and time columns.