### PR TITLE
Replace deprecated pretty_table keyword, noheader with show_header

### DIFF
--- a/src/DataSkimmer.jl
+++ b/src/DataSkimmer.jl
@@ -203,7 +203,7 @@ function Base.show(io::IO, summary::Summary)
     pretty_table(
         io,
         summary_table;
-        noheader = true,
+        show_header = false,
         backend = Val(:text),
         highlighters = (hl_col(1, Crayon(bold = true))),
     )


### PR DESCRIPTION
DataSkimmer tests were failing with this message:
```
MethodError: no method matching _print_table_with_text_back_end(::PrettyTables.PrintInfo; noheader::Bool, highlighters::PrettyTables.Highlighter)

  Closest candidates are:
    _print_table_with_text_back_end(::PrettyTables.PrintInfo; alignment_anchor_fallback, alignment_anchor_fallback_override, alignment_anchor_regex, autowrap, body_hlines, body_hlines_format, continuation_row_alignment, crop, crop_subheader, columns_width, display_size, equal_columns_width, ellipsis_line_skip, highlighters, hlines, linebreaks, maximum_columns_width, minimum_columns_width, newline_at_end, overwrite, reserved_display_lines, show_omitted_cell_summary, sortkeys, tf, title_autowrap, title_same_width_as_table, vcrop_mode, vlines, border_crayon, header_crayon, omitted_cell_summary_crayon, row_label_crayon, row_label_header_crayon, row_number_header_crayon, subheader_crayon, text_crayon, title_crayon, T, T) got unsupported keyword argument "noheader"
     @ PrettyTables ~/.julia/packages/PrettyTables/E8rPJ/src/backends/text/text_backend.jl:11

```
Scroll error to the right to see the relevant portion: got unsupported keyword argument "noheader"

PrettyTables v 2.0.0 replaced the `noheader` keyword with `show_header`
This PR fixes the DataSkimmer test error by replacing `noheader = true` by `show_header = false`